### PR TITLE
Add option to filter on list of databases

### DIFF
--- a/server/dumpbagserver/bagger.py
+++ b/server/dumpbagserver/bagger.py
@@ -20,7 +20,11 @@ class Bagger():
         db_commander = DatabaseCommander.new_commander(
             self.config.database_options()
         )
-        self.db = Database(db_commander, exclude=self.config.exclude_databases)
+        self.db = Database(
+            db_commander,
+            only=config.only_databases,
+            exclude=self.config.exclude_databases
+        )
         self.storage = StorageCommander.new_commander(
             self.config.storage_options()
         )

--- a/server/dumpbagserver/config.py
+++ b/server/dumpbagserver/config.py
@@ -15,7 +15,15 @@ class FlaskConfig(object):
 class DumpBagConfig(object):
     """ Configuration """
 
-    exclude_databases = env.get('BAG_EXCLUDE_DATABASE', '').split(',')
+    @property
+    def only_databases(self):
+        only = env.get('BAG_ONLY_DATABASE', '').strip()
+        return only.split(',') if only else []
+
+    @property
+    def exclude_databases(self):
+        exclude = env.get('BAG_EXCLUDE_DATABASE', '').strip()
+        return exclude.split(',') if exclude else []
 
     @property
     def database_kind(self):

--- a/server/dumpbagserver/database.py
+++ b/server/dumpbagserver/database.py
@@ -84,7 +84,7 @@ class PostgresDatabaseCommander(DatabaseCommander):
         command = [
             'psql',
             '--host', self.options.host,
-            '--port', self.options.port,
+            '--port', str(self.options.port),
             '--username', self.options.user,
             '--quiet', '--no-align', '--tuples-only',
             '--dbname', 'postgres',
@@ -128,7 +128,7 @@ class PostgresOptions(DatabaseOptions):
     """ Options for the PostgreSQL commander """
     _commander = PostgresDatabaseCommander
 
-    def __init__(self, host, user, password, port=5432):
+    def __init__(self, host, user, password, port='5432'):
         self.host = host
         self.port = port
         self.user = user
@@ -137,15 +137,17 @@ class PostgresOptions(DatabaseOptions):
 
 class Database():
 
-    def __init__(self, commander, exclude=None):
+    def __init__(self, commander, only=None, exclude=None):
+        self.only = only
         self.exclude = exclude
         self.commander = commander
 
     def list_databases(self):
         databases = self.commander.list_databases()
+        if self.only:
+            databases = [db for db in databases if db in self.only]
         if self.exclude:
-            databases = [db for db in databases
-                         if db not in self.exclude]
+            databases = [db for db in databases if db not in self.exclude]
         return databases
 
     def _generate_dump_name(self, dbname):

--- a/server/tests/test_database.py
+++ b/server/tests/test_database.py
@@ -39,6 +39,13 @@ def db_with_exclude(commander):
     )
 
 
+@pytest.fixture
+def db_with_only(commander):
+    return database.Database(
+        commander, only=['db1', 'db2']
+    )
+
+
 def test_commander_factory(static_options, postgres_options):
     cmd = database.DatabaseCommander.new_commander(
         static_options
@@ -63,6 +70,11 @@ def test_list_database_exclude(db_with_exclude):
     db_with_exclude.exclude = ['postgres', 'template0', 'template1']
     dbs = db_with_exclude.list_databases()
     assert dbs == ['db1', 'db2', 'db3']
+
+
+def test_list_database_only(db_with_only):
+    dbs = db_with_only.list_databases()
+    assert dbs == ['db1', 'db2']
 
 
 def test_dump_db_not_exist(tmpdir, db_with_exclude):


### PR DESCRIPTION
It completes the 'exclude' option which allow to remove databases from
the list. For some environments, we might prefer to whitelist databases,
for instance we have one odoo database to backup and varying other
databases.